### PR TITLE
Updated to 78.0-beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Checkout the desired release. Releases can be found in the the [Google group](ht
 To build the framework with bitcode support, pass the `--bitcode` flag to the `build_ios_libs` script found in `/tools_webrtc/ios`.
 
 ```bash
-python build_ios_libs.py —bitcode
+python build_ios_libs.py -—bitcode
 ```
 
 The resulting framework can be found in `/out_ios_libs/`.

--- a/WebRTC.json
+++ b/WebRTC.json
@@ -1,4 +1,5 @@
 {
   "70.0.0":"https://github.com/ecobee/webrtc-ios/releases/download/70.0.0/WebRTC.framework.zip",
-  "76.0":"https://github.com/ecobee/webrtc-ios/releases/download/76.0/WebRTC.framework.zip"
+  "76.0":"https://github.com/ecobee/webrtc-ios/releases/download/76.0/WebRTC.framework.zip",
+  "78.0-beta":"https://github.com/ecobee/webrtc-ios/releases/download/78.0-beta/WebRTC.framework.zip"
 }


### PR DESCRIPTION
Updating to a beta version of WebRTC because it better supports iOS 13.