### PR TITLE
Fixed filename in build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -50,5 +50,6 @@ cd "${build_dir}/src/tools_webrtc/ios"
 python build_ios_libs.py --arch {arm64,arm} --bitcode --revision "${version}"
 cd "${build_dir}/src/out_ios_libs"
 timestamp=$(date +%s)
-zip -r "WebRTC_${timestamp}.zip" .
-mv WebRTC.framework.zip "${build_dir}"
+filename="WebRTC_${timestamp}.zip"
+zip -r $filename .
+mv $filename "${build_dir}"

--- a/config.sh
+++ b/config.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
+
 branch="branch-heads/4103"
 version="83"


### PR DESCRIPTION
## Changes
- Incorrect filename was used in build script causing an error when moving the zip file.
- Added space to config file so that the job will run again on merge.